### PR TITLE
feat(healthz): Return latest crontab_stats grouped by name (fleetdm/fleet#14392)

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -840,8 +840,12 @@ the way that the Fleet server works.
 			launcher := launcher.New(svc, logger, grpc.NewServer(), healthCheckers)
 
 			rootMux := http.NewServeMux()
-			cronStats, _ := ds.GetHealthCheckCronStats()
 			rootMux.Handle("/healthz", service.PrometheusMetricsHandler("healthz", health.Handler(httpLogger, healthCheckers, func() any {
+				cronStats, err := ds.GetHealthCheckCronStats()
+				if err != nil {
+					_ = level.Error(logger).Log("Could not retrieve cron_stats for health check", err)
+					return map[any]any{}
+				}
 				return cronStats
 			})))
 			rootMux.Handle("/version", service.PrometheusMetricsHandler("version", version.Handler()))

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -840,7 +840,10 @@ the way that the Fleet server works.
 			launcher := launcher.New(svc, logger, grpc.NewServer(), healthCheckers)
 
 			rootMux := http.NewServeMux()
-			rootMux.Handle("/healthz", service.PrometheusMetricsHandler("healthz", health.Handler(httpLogger, healthCheckers)))
+			cronStats, _ := ds.GetHealthCheckCronStats()
+			rootMux.Handle("/healthz", service.PrometheusMetricsHandler("healthz", health.Handler(httpLogger, healthCheckers, func() any {
+				return cronStats
+			})))
 			rootMux.Handle("/version", service.PrometheusMetricsHandler("version", version.Handler()))
 			rootMux.Handle("/assets/", service.PrometheusMetricsHandler("static_assets", service.ServeStaticAssets("/assets/")))
 

--- a/server/datastore/mysql/cron_stats.go
+++ b/server/datastore/mysql/cron_stats.go
@@ -7,15 +7,6 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-/*
-type CronStatsForHealthCheck struct {
-	Name      string    `db:"name" json:"name"`
-	Status    string    `db:"status" json:"status"`
-	CreatedAt time.Time `db:"created_at" json:"created"`
-	UpdatedAt time.Time `db:"updated_at" json:"updated"`
-}
-*/
-
 // GetLatestCronStats returns a slice of no more than two cron stats records, where index 0 (if
 // present) is the most recently created scheduled run, and index 1 (if present) represents a
 // triggered run that is currently pending.

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/fleetdm/fleet/v4/server/health"
 	"io/ioutil"
 	"net/url"
 	"regexp"
@@ -694,6 +695,33 @@ func (ds *Datastore) HealthCheck() error {
 		}
 	}
 	return nil
+}
+
+func (ds *Datastore) GetHealthCheckCronStats() ([]health.CronStats, error) {
+	rows, err := ds.primary.QueryContext(context.Background(), `
+		SELECT cs1.name, cs1.status, cs1.created_at, updated_at
+		FROM cron_stats AS cs1
+				 JOIN (SELECT name, MAX(updated_at) AS upd -- can't include id due to sql_mode=only_full_group_by
+						FROM cron_stats
+						GROUP BY name) AS cs2
+					   ON cs1.updated_at = cs2.upd AND cs1.name = cs2.name
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var stats []health.CronStats
+	for rows.Next() {
+		var alb health.CronStats
+		if err := rows.Scan(&alb.Name, &alb.Status, &alb.CreatedAt, &alb.UpdatedAt); err != nil {
+			return stats, err
+		}
+		stats = append(stats, alb)
+	}
+	if err = rows.Err(); err != nil {
+		return stats, err
+	}
+	return stats, nil
 }
 
 func (ds *Datastore) closeStmts() error {

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -162,6 +162,13 @@ type CronStats struct {
 	Status CronStatsStatus `db:"status"`
 }
 
+type CronStatsForHealthCheck struct {
+	Name      string    `db:"name" json:"name"`
+	Status    string    `db:"status" json:"status"`
+	CreatedAt time.Time `db:"created_at" json:"created"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated"`
+}
+
 // CronStatsType is one of two recognized types of cron stats (i.e. "scheduled" or "triggered")
 type CronStatsType string
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -600,6 +600,8 @@ type Datastore interface {
 	UpdateAllCronStatsForInstance(ctx context.Context, instance string, fromStatus CronStatsStatus, toStatus CronStatsStatus) error
 	// CleanupCronStats cleans up expired cron stats.
 	CleanupCronStats(ctx context.Context) error
+	// GetHealthCheckCronStats is meant for use by /healthz endpoint
+	GetHealthCheckCronStats() ([]CronStatsForHealthCheck, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Aggregated Stats

--- a/server/health/health.go
+++ b/server/health/health.go
@@ -3,6 +3,7 @@ package health
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/go-kit/kit/log"
 )
@@ -40,6 +41,8 @@ func Handler(logger log.Logger, allCheckers map[string]Checker) http.HandlerFunc
 		}
 
 		healthy := CheckHealth(logger, checkers)
+		//cronStats, _ := ds.GetHealthCheckCronStats()
+		//_ = json.NewEncoder(w).Encode(cronStats)
 		if !healthy {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -67,6 +70,13 @@ func Nop() Checker {
 }
 
 type nop struct{}
+
+type CronStats struct {
+	Name      string    `db:"name" json:"name"`
+	Status    string    `db:"status" json:"status"`
+	CreatedAt time.Time `db:"created_at" json:"created"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated"`
+}
 
 func (c nop) HealthCheck() error {
 	return nil

--- a/server/health/health.go
+++ b/server/health/health.go
@@ -17,7 +17,8 @@ type Checker interface {
 // Handler responds with either:
 // 200 OK if the server can successfully communicate with it's backends or
 // 500 if any of the backends are reporting an issue.
-func Handler(logger log.Logger, allCheckers map[string]Checker, cronTabHandler func() any) http.HandlerFunc {
+// getResponseBody provides JSON-marshallable content.
+func Handler(logger log.Logger, allCheckers map[string]Checker, getResponseBody func() any) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		checkers := make(map[string]Checker)
 		checks, ok := r.URL.Query()["check"]
@@ -40,7 +41,7 @@ func Handler(logger log.Logger, allCheckers map[string]Checker, cronTabHandler f
 		}
 
 		healthy := CheckHealth(logger, checkers)
-		_ = json.NewEncoder(w).Encode(cronTabHandler())
+		_ = json.NewEncoder(w).Encode(getResponseBody())
 		if !healthy {
 			w.WriteHeader(http.StatusInternalServerError)
 			return

--- a/server/health/health.go
+++ b/server/health/health.go
@@ -4,6 +4,7 @@ package health
 import (
 	"encoding/json"
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 	"net/http"
 )
 
@@ -41,9 +42,15 @@ func Handler(logger log.Logger, allCheckers map[string]Checker, getResponseBody 
 		}
 
 		healthy := CheckHealth(logger, checkers)
-		_ = json.NewEncoder(w).Encode(getResponseBody())
 		if !healthy {
 			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+		encoder := json.NewEncoder(w)
+		body := getResponseBody()
+		err := encoder.Encode(body)
+		if err != nil {
+			_ = level.Error(logger).Log("While encoding to JSON", body)
 			return
 		}
 	}

--- a/server/health/health_test.go
+++ b/server/health/health_test.go
@@ -44,13 +44,19 @@ func TestHealthzHandler(t *testing.T) {
 
 	fail := Handler(logger, map[string]Checker{
 		"mock": failCheck,
+	}, func() any {
+		return nil
 	})
 	pass := Handler(logger, map[string]Checker{
 		"mock": passCheck,
+	}, func() any {
+		return nil
 	})
 	both := Handler(logger, map[string]Checker{
 		"pass": passCheck,
 		"fail": failCheck,
+	}, func() any {
+		return nil
 	})
 
 	httpTests := []struct {

--- a/server/mock/datastore.go
+++ b/server/mock/datastore.go
@@ -33,3 +33,5 @@ func (m *Store) MigrationStatus(ctx context.Context) (*fleet.MigrationStatus, er
 	return &fleet.MigrationStatus{}, nil
 }
 func (m *Store) Name() string { return "mock" }
+
+func (m *Store) GetHealthCheckCronStats() ([]fleet.CronStatsForHealthCheck, error) { return nil, nil }


### PR DESCRIPTION
A demonstration PR, as a starting point of conversation with fleetdm regarding fleetdm/fleet# 14392 (trying not to link back to the original issue directly not to disturb the fleetdm team (sorry! 😬) .

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/` or `orbit/changes/`.
  See [Changes files](https://fleetdm.com/docs/contributing/committing-changes#changes-files) for more information.
- [ ] Documented any API changes (docs/Using-Fleet/REST-API.md or docs/Contributing/API-for-contributors.md)
- [ ] Documented any permissions changes (docs/Using Fleet/manage-access.md)
- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] Added support on fleet's osquery simulator `cmd/osquery-perf` for new osquery data ingestion features.
- [ ] Added/updated tests
- [ ] Manual QA for all new/changed functionality
  - For Orbit and Fleet Desktop changes:
    - [ ] Manual QA must be performed in the three main OSs, macOS, Windows and Linux.
    - [ ] Auto-update manual QA, from released version of component to new version (see [tools/tuf/test](../tools/tuf/test/README.md)).
